### PR TITLE
✏️  typo: replace readyz and healthz in sentinel probe-api (Restart o…

### DIFF
--- a/cmd/proxy/cmd/proxy.go
+++ b/cmd/proxy/cmd/proxy.go
@@ -481,7 +481,7 @@ func proxy(c *cobra.Command, args []string) {
 		})
 		probeServer.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`I'm ready`))
+			w.Write([]byte(`I'm Ready`))
 			return
 		})
 		go func() {

--- a/cmd/sentinel/cmd/sentinel.go
+++ b/cmd/sentinel/cmd/sentinel.go
@@ -2024,12 +2024,8 @@ func sentinel(c *cobra.Command, args []string) {
 
 	if cfg.HealthProbeListenAddress != "" {
 		probeServer := http.NewServeMux()
+
 		probeServer.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`I'm Healthy`))
-			return
-		})
-		probeServer.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
 			e, err := cmd.NewStore(&cfg.CommonConfig)
 			if err != nil {
 				w.WriteHeader(http.StatusInternalServerError)
@@ -2073,7 +2069,12 @@ func sentinel(c *cobra.Command, args []string) {
 				return
 			}
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`I'm ready`))
+			w.Write([]byte(`I'm Healthy`))
+			return
+		})
+		probeServer.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`I'm Ready`))
 			return
 		})
 		go func() {


### PR DESCRIPTION
…n no master avaiable in K8s environment)